### PR TITLE
Symlink for textadept

### DIFF
--- a/Numix-Circle/48x48/apps/textadept.svg
+++ b/Numix-Circle/48x48/apps/textadept.svg
@@ -1,0 +1,1 @@
+wxmedit.svg


### PR DESCRIPTION
Linked it against ``wxmedit.svg`` so there's a bit more distinctness.